### PR TITLE
check tests based on perlport implementation

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -24,6 +24,14 @@ export ZOPEN_CHECK_OPTS="test"
 
 zopen_check_results()
 {
-return 3 # Non-functional
-}
+chk="$2_check.log"
 
+successes=$(grep -E " ok$" ${chk} | wc -l)
+totalTests=$(grep -E "^Failed | ok$" ${chk} | wc -l)
+failures="$((totalTests-successes))"
+cat <<ZZ
+actualFailures:$failures
+totalTests:$totalTests
+expectedFailures:0
+ZZ
+}


### PR DESCRIPTION
Using perlport's implementation as a model, added test failure counts to buildenv