### PR TITLE
Set up env vars for use by other tools using openssl libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ openssl
 pax_global_header
 install/
 log/
+patches

--- a/buildenv
+++ b/buildenv
@@ -29,6 +29,21 @@ export ZOPEN_EXTRA_CFLAGS="${ZOPEN_EXTRA_CFLAGS} -std=gnu99"
 export ZOPEN_EXTRA_CPPFLAGS="${ZOPEN_EXTRA_CPPFLAGS} -DNI_MAXSERV=32 -DNI_MAXHOST=1025"
 export LDLIBS="${ZOPEN_EXTRA_LIBS}"
 
+zopen_append_to_env()
+{
+cat <<ZZ
+if [ ! -z "\$ZOPEN_IN_ZOPEN_BUILD" ]; then
+  export ZOPEN_EXTRA_CFLAGS="\${ZOPEN_EXTRA_CFLAGS} -I\$PWD/include"
+  export ZOPEN_EXTRA_CXXFLAGS="\${ZOPEN_EXTRA_CXXFLAGS} -I\$PWD/include"
+  export ZOPEN_EXTRA_LDFLAGS="\${ZOPEN_EXTRA_LDFLAGS} -L\$PWD/lib"
+  export ZOPEN_EXTRA_LIBS="\${ZOPEN_EXTRA_LIBS} -lcrypto -lssl"
+
+  export OPENSSL_CFLAGS="-I\$PWD/include"
+  export OPENSSL_LDFLAGS="-L\$PWD/lib"
+fi
+ZZ
+}
+
 zopen_check_results()
 {
 chk="$1/$2_check.log"

--- a/buildenv
+++ b/buildenv
@@ -38,8 +38,12 @@ if [ ! -z "\$ZOPEN_IN_ZOPEN_BUILD" ]; then
   export ZOPEN_EXTRA_LDFLAGS="\${ZOPEN_EXTRA_LDFLAGS} -L\$PWD/lib"
   export ZOPEN_EXTRA_LIBS="\${ZOPEN_EXTRA_LIBS} -lcrypto -lssl"
 
+  #
+  # These are required for wget
+  #
   export OPENSSL_CFLAGS="-I\$PWD/include"
   export OPENSSL_LDFLAGS="-L\$PWD/lib"
+  export OPENSSL_LIBS="-lcrypto -lssl"
 fi
 ZZ
 }


### PR DESCRIPTION
I used the zoslib model as a template and added new environment variables that only run when used from `zopen-build` so that other tools can use them easier.
This also let me solve a problem where wget needed particular env vars outside of the CFLAGS/CPPFLAGS/LDFLAGS. Without setting these variables here, I would have needed a new function call out to set the environment variables _after_ all the dependencies had been run for wget so that OPENSSL_HOME would be resolved.