### PR TITLE
Force build with clang and update to latest version openssl-1.1.1t

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -10,7 +10,7 @@ if [ ! -z "$OPENSSL_HW_BUILD" ]; then
   ln -s hardware_patches patches
 else
   printHeader "Building SW openssl"
-  export ZOPEN_TARBALL_URL="https://www.openssl.org/source/openssl-1.1.1s.tar.gz"
+  export ZOPEN_TARBALL_URL="https://www.openssl.org/source/openssl-1.1.1t.tar.gz"
   export ZOPEN_TARBALL_DEPS="curl git gzip make m4 perl tar zoslib"
   rm -f patches
   ln -s software_patches patches
@@ -28,6 +28,7 @@ export ZOPEN_CHECK_OPTS="test"
 export ZOPEN_EXTRA_CFLAGS="${ZOPEN_EXTRA_CFLAGS} -std=gnu99"
 export ZOPEN_EXTRA_CPPFLAGS="${ZOPEN_EXTRA_CPPFLAGS} -DNI_MAXSERV=32 -DNI_MAXHOST=1025"
 export LDLIBS="${ZOPEN_EXTRA_LIBS}"
+export ZOPEN_COMP=clang
 
 zopen_append_to_env()
 {


### PR DESCRIPTION
* In my manual run, there was only one failure. Will confirm with Jenkins and then update the expectedFailures accordingly.