### PR TITLE
Add ENOSYS condition for tty open failure.

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -67,7 +67,8 @@ else
   cat <<ZZ
   actualFailures:$failures
   totalTests:$totalTests
-  expectedFailures:12
+# 1 failure is expected as IPv6 not enabled on jenkins machines
+  expectedFailures:1
 ZZ
 fi
 }

--- a/stable-patches/ui_disable.patch
+++ b/stable-patches/ui_disable.patch
@@ -1,0 +1,19 @@
+diff --git a/crypto/ui/ui_openssl.c b/crypto/ui/ui_openssl.c
+index 544415e..57489e9 100644
+--- a/crypto/ui/ui_openssl.c
++++ b/crypto/ui/ui_openssl.c
+@@ -455,6 +455,14 @@ static int open_console(UI *ui)
+                 is_a_tty = 0;
+         else
+ #  endif
++# if defined(__MVS__) && defined(ENOSYS)
++            /*
++             * In Jenkins Non-Interactive build
++             */
++        if (errno == ENOSYS)
++                is_a_tty = 0;
++        else
++# endif
+             {
+                 ERR_raise_data(ERR_LIB_UI, UI_R_UNKNOWN_TTYGET_ERRNO_VALUE,
+                                "errno=%d", errno);


### PR DESCRIPTION
1. Added condition for tty open failure in Jenkins machine, as it runs in a non-interactive session.
2. updated expected failure.